### PR TITLE
Update README with Whoop API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ pip install -r requirements.txt
 
 DATABASE_URI = SQLAlchemy URI to your Database
 SECRET_KEY = Your secret key for the flask app
+CLIENT_ID = OAuth2 client ID for Whoop API integration
+CLIENT_SECRET = OAuth2 client secret for Whoop API integration
 
 ## Running The App
 


### PR DESCRIPTION
## Summary
- document additional environment variables for Whoop OAuth2 integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a25d93a108322a690861f266476e7